### PR TITLE
Holds smart pointers at the m_players instead raw pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.5)
 project(MicroService)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")

--- a/src/Application.h
+++ b/src/Application.h
@@ -80,7 +80,7 @@ private:
     std::unique_ptr<DataBase::DataBase> m_localStorage;
     std::unique_ptr<AMQP::TcpChannel> m_channel;
     ProcessingHadlers m_handlers;
-    std::vector<Player *> m_players;
+    std::vector<std::unique_ptr<Player>> m_players;
     std::unordered_map<uint64_t, Player *> m_id2player;
 };
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -11,6 +11,13 @@ Player::Player()
 {
 }
 
+Player::Player(uint64_t id, const std::string& name)
+    : id(id)
+    , name(name)
+    , points(0)
+{
+}
+
 Player::Player(const DataBase::ByteArray &data)
 {
 //todo выпилить stringstream для оптимизации

--- a/src/Player.h
+++ b/src/Player.h
@@ -11,6 +11,7 @@ namespace MicroService
 struct Player
 {
     Player();
+    Player(uint64_t id, const std::string& name);
 
     /*!
      * deserialize


### PR DESCRIPTION
POC.
Also, decrease required cmake version to 3.5: now it works well on Ubuntu 16.04 / Mint 18 out of box.